### PR TITLE
Migrate search from mysql3 to sqlalchemy3

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,2 +1,5 @@
 [pep8]
 ignore = E128,E127,E126
+
+[flake8]
+ignore = E128,E127,E126

--- a/test/test_search.py
+++ b/test/test_search.py
@@ -1,0 +1,334 @@
+import py.test
+from tiddlyweb.config import config
+
+from tiddlyweb.model.tiddler import Tiddler
+from tiddlyweb.model.bag import Bag
+
+from tiddlywebplugins.utils import get_store
+
+from tiddlywebplugins.sqlalchemy3 import index_query, Base
+
+def setup_module(module):
+    module.store = get_store(config)
+    module.environ = {'tiddlyweb.config': config,
+            'tiddlyweb.store': module.store}
+    session = module.store.storage.session
+# delete everything
+    Base.metadata.drop_all()
+    Base.metadata.create_all()
+
+def test_simple_store():
+    bag = Bag('bag1')
+    store.put(bag)
+    tiddler = Tiddler('tiddler1', 'bag1')
+    tiddler.text = u'oh hello i chrisdent have nothing to say here you know'
+    tiddler.tags = [u'apple', u'orange', u'pear']
+    tiddler.fields[u'house'] = u'cottage'
+    store.put(tiddler)
+
+    retrieved = Tiddler('tiddler1', 'bag1')
+    retrieved = store.get(retrieved)
+
+    assert retrieved.text == tiddler.text
+
+def test_simple_search():
+    tiddlers = list(store.search('chrisdent'))
+    assert len(tiddlers) == 1
+    assert tiddlers[0].title == 'tiddler1'
+    assert tiddlers[0].bag == 'bag1'
+
+    tiddlers = list(store.search('hello'))
+    assert len(tiddlers) == 1
+    assert tiddlers[0].title == 'tiddler1'
+    assert tiddlers[0].bag == 'bag1'
+
+def test_index_query_id():
+    kwords = {'id': u'bag1:tiddler1'}
+    tiddlers = list(index_query(environ, **kwords))
+
+    assert len(tiddlers) == 1
+    assert tiddlers[0].title == 'tiddler1'
+    assert tiddlers[0].bag == 'bag1'
+
+def test_index_query_filter():
+    kwords = {'tag': u'orange'}
+    tiddlers = list(index_query(environ, **kwords))
+
+    assert len(tiddlers) == 1
+    assert tiddlers[0].title == 'tiddler1'
+    assert tiddlers[0].bag == 'bag1'
+
+def test_index_query_filter_fields():
+    kwords = {'house': u'cottage'}
+    tiddlers = list(index_query(environ, **kwords))
+
+    assert len(tiddlers) == 1
+    assert tiddlers[0].title == 'tiddler1'
+    assert tiddlers[0].bag == 'bag1'
+    assert tiddlers[0].fields['house'] == 'cottage'
+
+    kwords = {u'house': u'mansion'}
+    tiddlers = list(index_query(environ, **kwords))
+
+    assert len(tiddlers) == 0
+
+def test_index_query_filter_fields():
+    kwords = {'bag': u'bag1', 'house': u'cottage'}
+    tiddlers = list(index_query(environ, **kwords))
+
+    assert len(tiddlers) == 1
+    assert tiddlers[0].title == 'tiddler1'
+    assert tiddlers[0].bag == 'bag1'
+    assert tiddlers[0].fields['house'] == 'cottage'
+
+def test_search_right_revision():
+    tiddler = Tiddler('revised', 'bag1')
+    tiddler.text = u'alpha'
+    tiddler.fields[u'house'] = u'cottage'
+    store.put(tiddler)
+    tiddler = Tiddler('revised', 'bag1')
+    tiddler.text = u'beta'
+    tiddler.fields[u'house'] = u'mansion'
+    store.put(tiddler)
+    tiddler = Tiddler('revised', 'bag1')
+    tiddler.text = u'gamma'
+    tiddler.fields[u'house'] = u'barn'
+    store.put(tiddler)
+    tiddler = Tiddler('revised', 'bag1')
+    tiddler.text = u'delta'
+    tiddler.fields[u'house'] = u'bungalow'
+    store.put(tiddler)
+    tiddler = Tiddler('revised', 'bag1')
+    tiddler.text = u'epsilon'
+    tiddler.fields[u'house'] = u'treehouse'
+    store.put(tiddler)
+
+    tiddlers = list(store.search('beta'))
+    assert len(tiddlers) == 0
+
+    tiddlers = list(store.search('epsilon'))
+    assert len(tiddlers) == 1
+    tiddler = store.get(Tiddler(tiddlers[0].title, tiddlers[0].bag))
+    assert tiddler.title == 'revised'
+    assert tiddler.bag == 'bag1'
+    assert tiddler.fields['house'] == 'treehouse'
+
+    kwords = {'bag': u'bag1', 'house': u'barn'}
+    tiddlers = list(index_query(environ, **kwords))
+
+    assert len(tiddlers) == 0
+
+    kwords = {'bag': u'bag1', 'house': u'treehouse'}
+    tiddlers = list(index_query(environ, **kwords))
+
+    assert tiddlers[0].title == 'revised'
+    assert tiddlers[0].bag == 'bag1'
+    assert tiddlers[0].fields['house'] == 'treehouse'
+
+    kwords = {'bag': u'bag1', 'tag': u'orange'}
+    tiddlers = list(index_query(environ, **kwords))
+
+    assert len(tiddlers) == 1
+
+    kwords = {'bag': u'bag1', 'tag': u'rang'}
+    tiddlers = list(index_query(environ, **kwords))
+
+    assert len(tiddlers) == 0
+
+def test_search_follow_syntax():
+    QUERY = u'ftitle:GettingStarted (bag:cdent_public OR bag:fnd_public)'
+
+    store.put(Bag('fnd_public'))
+    store.put(Bag('cdent_public'))
+    tiddler = Tiddler('GettingStarted', 'fnd_public')
+    tiddler.text = u'fnd starts'
+    tiddler.fields[u'house'] = u'treehouse'
+    tiddler.fields[u'car'] = u'porsche'
+    store.put(tiddler)
+    tiddler = Tiddler('GettingStarted', 'cdent_public')
+    tiddler.text = u'cdent starts'
+    tiddler.fields[u'left-hand'] = u'well dirty'
+    store.put(tiddler)
+    tiddler = Tiddler('other', 'cdent_public')
+    tiddler.text = u'cdent starts'
+    store.put(tiddler)
+
+    tiddlers = list(store.search(u'starts'))
+    assert len(tiddlers) == 3
+
+    tiddlers = list(store.search(QUERY))
+    assert len(tiddlers) == 2
+
+    tiddlers = list(store.search(u'cdent starts'))
+    assert len(tiddlers) == 2
+
+    tiddlers = list(store.search(u'fnd starts'))
+    assert len(tiddlers) == 1
+
+    tiddler = list(store.search(u'left-hand:"well dirty"'))
+    assert len(tiddlers) == 1
+
+def test_search_arbitrarily_complex():
+    QUERY = u'ftitle:GettingStarted (bag:cdent_public OR bag:fnd_public) house:treehouse'
+
+    tiddlers = list(store.search(QUERY))
+    assert len(tiddlers) == 1
+
+    QUERY = u'ftitle:GettingStarted ((bag:cdent_public OR bag:fnd_public) AND (house:treehouse AND car:porsche))'
+
+    tiddlers = list(store.search(QUERY))
+    assert len(tiddlers) == 1
+
+def test_field_with_dot():
+    tiddler = Tiddler('geoplace', 'cdent_public')
+    tiddler.text = u'some place somewhere'
+    tiddler.fields[u'geo.lat'] = u'1.25'
+    tiddler.fields[u'geo.long'] = u'-45.243'
+    store.put(tiddler)
+
+    tiddlers = list(store.search(u'geo.lat:1.2*'))
+
+    assert len(tiddlers) == 1
+
+    tiddlers = list(store.search(u'geo.lat:"1.2*" AND geo.long:"-45.*"'))
+
+    assert len(tiddlers) == 1
+    
+    tiddlers = list(store.search(u'geo.lat:"1.3*" AND geo.long:"-46.*"'))
+
+    assert len(tiddlers) == 0
+
+    tiddlers = list(store.search(u'geo.lat:"1.2*" OR geo.long:"-46.*"'))
+
+    assert len(tiddlers) == 1
+
+def test_limited_search():
+    tiddlers = list(store.search(u'starts _limit:1'))
+    assert len(tiddlers) == 1, tiddlers
+
+    tiddlers = list(store.search(u'starts'))
+    assert len(tiddlers) != 1, tiddlers
+
+    tiddlers = list(store.search(u'starts _limit:so'))
+    assert len(tiddlers) != 1, tiddlers
+
+def test_modified():
+    """
+    Note the multiple store.put in here are to create
+    additional revisions to make sure that joins are
+    sufficiently limited.
+    """
+    tiddler = Tiddler('GettingStarted', 'fnd_public')
+    tiddler.modifier = u'fnd';
+    store.put(tiddler)
+
+    tiddlers = list(store.search(u'modifier:fnd'))
+
+    assert len(tiddlers) == 1
+
+    tiddler = Tiddler('GettingStarted', 'fnd_public')
+    tiddler.tags = [u'monkey', u'cow', u'food']
+    tiddler.modifier = u'cdent';
+    store.put(tiddler)
+    store.put(tiddler)
+    store.put(tiddler)
+    store.put(tiddler)
+
+    tiddlers = list(store.search(u'modifier:fnd'))
+
+    assert len(tiddlers) == 0
+
+    tiddler = Tiddler('GettingFancy', 'fnd_public')
+    tiddler.tags = [u'cow', u'food']
+    tiddler.modifier = u'fnd';
+    store.put(tiddler)
+    store.put(tiddler)
+    store.put(tiddler)
+    store.put(tiddler)
+
+    tiddlers = list(store.search(u'modifier:fnd OR modifier:cdent'))
+
+    assert len(tiddlers) == 2
+
+    tiddlers = list(store.search(u'modifier:fnd NOT modifier:cdent'))
+
+    assert len(tiddlers) == 1
+
+    tiddlers = list(store.search(u'modifier:fnd NOT (modifier:cdent OR title:GettingStarted)'))
+
+    assert len(tiddlers) == 1
+
+    tiddlers = list(store.search(u'modifier:fnd AND modified:20*'))
+
+    assert len(tiddlers) == 1
+
+def test_not():
+    py.test.skip('need better sql-fu to get this right')
+    # If we do a group by tag in the query we get reasonable 
+    # results but we can't effectively produce that group by in
+    # the face of other arbitrary queries.
+    tiddlers = list(store.search(u'bag:fnd_public NOT tag:monkey'))
+    assert len(tiddlers) == 1
+
+def test_or_tags():
+    tiddler = Tiddler('tagone', 'fnd_public')
+    tiddler.text = 'hi @onething hello'
+    tiddler.tags = ['one','three', 'five']
+    store.put(tiddler)
+
+    tiddler = Tiddler('tagtwo', 'fnd_public')
+    tiddler.text = 'hi @twothing hello'
+    tiddler.tags = ['two', 'four', 'six']
+    store.put(tiddler)
+
+    tiddlers = list(store.search(u'@twothing OR tag:one'))
+
+    assert len(tiddlers) == 2
+
+def test_at_tags():
+    tiddler = Tiddler('tagat', 'fnd_public')
+    tiddler.text = 'new stuff to not mess'
+    tiddler.tags = ['one','three', 'five', '@cdent']
+    store.put(tiddler)
+
+    tiddlers = list(store.search(u'tag:@cdent'))
+
+    assert len(tiddlers) == 1
+
+def test_paren_title():
+    tiddler = Tiddler('(i)', 'fnd_public')
+    tiddler.text = 'hi @onething hello'
+    tiddler.tags = ['one','three', 'five']
+    store.put(tiddler)
+
+    tiddlers = list(store.search(u'title:(i)'))
+
+    assert len(tiddlers) == 1
+    assert tiddlers[0].title == '(i)'
+
+def test_text_as_field():
+    tiddlers = list(store.search(u'text:hello'))
+
+    assert len(tiddlers) == 4, tiddlers
+
+def test_srevision_attr():
+    tiddlers = list(store.search(u'fields:hello'))
+
+    assert len(tiddlers) == 0, tiddlers
+
+def test_tiddler_field_join():
+    tiddler = Tiddler('fieldtest', 'fnd_public')
+    tiddler.text = 'hi again'
+    tiddler.fields = {
+            u'barney': u'evil',
+            u'soup': u'good',
+    }
+    store.put(tiddler)
+
+    tiddlers = list(store.search(u'barney:evil'))
+    assert len(tiddlers) == 1
+    assert tiddlers[0].title == 'fieldtest'
+
+    tiddlers = list(store.search(u'barney:evil AND soup:good'))
+    assert len(tiddlers) == 1
+    assert tiddlers[0].title == 'fieldtest'

--- a/test/test_search.py
+++ b/test/test_search.py
@@ -58,7 +58,7 @@ def test_index_query_filter():
     assert tiddlers[0].title == 'tiddler1'
     assert tiddlers[0].bag == 'bag1'
 
-def test_index_query_filter_fields():
+def test_index_query_filter_field():
     kwords = {'house': u'cottage'}
     tiddlers = list(index_query(environ, **kwords))
 
@@ -209,7 +209,8 @@ def test_limited_search():
     tiddlers = list(store.search(u'starts'))
     assert len(tiddlers) != 1, tiddlers
 
-    tiddlers = list(store.search(u'starts _limit:so'))
+    # confirm things don't explode when a non int limit is provided
+    tiddlers = list(store.search(u'starts _limit:notint'))
     assert len(tiddlers) != 1, tiddlers
 
 def test_modified():

--- a/tiddlywebplugins/sqlalchemy3/__init__.py
+++ b/tiddlywebplugins/sqlalchemy3/__init__.py
@@ -333,15 +333,14 @@ class Store(StorageInterface):
         parsed by the parser and turned into a producer.
         """
         query = self.session.query(sTiddler).join('current')
+        config = self.environ.get('tiddlyweb.config', {})
         if '_limit:' not in search_query:
-            default_limit = self.environ.get(
-                    'tiddlyweb.config', {}).get(
-                            'mysql.search_limit', '20')
+            default_limit = config.get('mysql.search_limit',
+                    config.get('sqlalchemy3.search_limit', '20'))
             search_query += ' _limit:%s' % default_limit
         try:
             try:
                 ast = self.parser(search_query)[0]
-                config = self.environ['tiddlyweb.config']
                 fulltext = config.get('mysql.fulltext', False)
                 query = self.producer.produce(ast, query, fulltext=fulltext)
             except ParseException, exc:

--- a/tiddlywebplugins/sqlalchemy3/__init__.py
+++ b/tiddlywebplugins/sqlalchemy3/__init__.py
@@ -21,7 +21,6 @@ from tiddlyweb.model.policy import Policy
 from tiddlyweb.model.recipe import Recipe
 from tiddlyweb.model.tiddler import Tiddler
 from tiddlyweb.model.user import User
-from tiddlyweb.serializer import Serializer
 from tiddlyweb.store import (NoBagError, NoRecipeError, NoTiddlerError,
         NoUserError, StoreError)
 from tiddlyweb.stores import StorageInterface
@@ -63,7 +62,6 @@ class Store(StorageInterface):
         Base.metadata.bind = engine
         Session.configure(bind=engine)
         self.session = Session()
-        self.serializer = Serializer('text')
 
         # turn on foreign keys for sqlite (the default engine)
         if 'sqlite' in self.store_type:

--- a/tiddlywebplugins/sqlalchemy3/__init__.py
+++ b/tiddlywebplugins/sqlalchemy3/__init__.py
@@ -51,6 +51,7 @@ class Store(StorageInterface):
         self.store_type = self._db_config().split(':', 1)[0]
         self.parser = DEFAULT_PARSER
         self.producer = Producer()
+        self.has_geo = False
         self._init_store()
 
     def _init_store(self):
@@ -342,7 +343,8 @@ class Store(StorageInterface):
             try:
                 ast = self.parser(search_query)[0]
                 fulltext = config.get('mysql.fulltext', False)
-                query = self.producer.produce(ast, query, fulltext=fulltext)
+                query = self.producer.produce(ast, query, fulltext=fulltext,
+                        geo=self.has_geo)
             except ParseException, exc:
                 raise StoreError('failed to parse search query: %s' % exc)
 

--- a/tiddlywebplugins/sqlalchemy3/__init__.py
+++ b/tiddlywebplugins/sqlalchemy3/__init__.py
@@ -23,7 +23,7 @@ from tiddlyweb.model.tiddler import Tiddler
 from tiddlyweb.model.user import User
 from tiddlyweb.serializer import Serializer
 from tiddlyweb.store import (NoBagError, NoRecipeError, NoTiddlerError,
-        NoUserError)
+        NoUserError, StoreError)
 from tiddlyweb.stores import StorageInterface
 from tiddlyweb.util import binary_tiddler
 
@@ -179,7 +179,7 @@ class Store(StorageInterface):
 
     def recipe_put(self, recipe):
         try:
-            srecipe = self._store_recipe(recipe)
+            self._store_recipe(recipe)
             self.session.commit()
         except:
             self.session.rollback()
@@ -215,7 +215,7 @@ class Store(StorageInterface):
 
     def bag_put(self, bag):
         try:
-            sbag = self._store_bag(bag)
+            self._store_bag(bag)
             self.session.commit()
         except:
             self.session.rollback()
@@ -276,7 +276,7 @@ class Store(StorageInterface):
             if not tiddler.bag:
                 raise NoBagError('bag required to save')
             try:
-                sbag = self.session.query(sBag.id).filter(sBag.name
+                self.session.query(sBag.id).filter(sBag.name
                         == tiddler.bag).one()
             except NoResultFound, exc:
                 raise NoBagError('bag %s must exist for tiddler save: %s'

--- a/tiddlywebplugins/sqlalchemy3/parser.py
+++ b/tiddlywebplugins/sqlalchemy3/parser.py
@@ -1,0 +1,92 @@
+"""
+A search query string parser that generates an ast to be used elsewhere
+to create an appropriate SQL query.
+"""
+
+from pyparsing import (printables, alphanums, OneOrMore, Group,
+        Combine, Suppress, Literal, CharsNotIn,
+        Word, Keyword, Empty, White, Forward, QuotedString, StringEnd)
+
+
+def _make_default_parser():
+    """
+    Define a search query grammar that basically amounts to:
+
+    term OR quoted terms OR fieldname:value OR fieldname:quoted value
+
+    with optional booleans between chunks.
+
+    Then return a parser for that grammar.
+
+    Borrowed from early Whoosh versions
+    """
+    escapechar = "\\"
+
+    wordtext = CharsNotIn('\\():"{}[] ')
+    escape = Suppress(escapechar) + (Word(printables, exact=1)
+            | White(exact=1))
+    wordtoken = Combine(OneOrMore(wordtext | escape))
+# A plain old word.
+    plainWord = Group(wordtoken).setResultsName("Word")
+
+# A range of terms
+    startfence = Literal("[") | Literal("{")
+    endfence = Literal("]") | Literal("}")
+    rangeitem = QuotedString('"') | wordtoken
+    openstartrange = Group(Empty()) + Suppress(Keyword("TO")
+            + White()) + Group(rangeitem)
+    openendrange = Group(rangeitem) + Suppress(White()
+            + Keyword("TO")) + Group(Empty())
+    normalrange = Group(rangeitem) + Suppress(White()
+            + Keyword("TO") + White()) + Group(rangeitem)
+    range = Group(startfence + (normalrange | openstartrange
+        | openendrange) + endfence).setResultsName("Range")
+
+# A word-like thing
+    generalWord = range | plainWord
+
+# A quoted phrase
+    quotedPhrase = Group(QuotedString('"')).setResultsName("Quotes")
+
+    expression = Forward()
+
+# Parentheses can enclose (group) any expression
+    parenthetical = Group((Suppress("(") + expression
+        + Suppress(")"))).setResultsName("Group")
+
+    boostableUnit = generalWord | quotedPhrase
+    boostedUnit = Group(boostableUnit + Suppress("^")
+            + Word("0123456789", ".0123456789")).setResultsName("Boost")
+
+# The user can flag that a parenthetical group, quoted phrase, or word
+# should be searched in a particular field by prepending 'fn:', where fn is
+# the name of the field.
+    fieldableUnit = parenthetical | boostedUnit | boostableUnit
+    fieldedUnit = Group(Word(alphanums + "_" + "-"
+        + ".") + Suppress(':') + fieldableUnit).setResultsName("Field")
+
+# Units of content
+    generalUnit = fieldedUnit | fieldableUnit
+
+    andToken = Keyword("AND", caseless=False)
+    orToken = Keyword("OR", caseless=False)
+    notToken = Keyword("NOT", caseless=False)
+
+    operatorAnd = Group(generalUnit + OneOrMore(
+        Suppress(White()) + Suppress(andToken) + Suppress(White())
+        + generalUnit)).setResultsName("And")
+    operatorOr = Group(generalUnit + OneOrMore(
+        Suppress(White()) + Suppress(orToken) + Suppress(White())
+        + generalUnit)).setResultsName("Or")
+    operatorNot = Group(Suppress(notToken) + Suppress(White()) +
+        generalUnit).setResultsName("Not")
+
+    expression << (OneOrMore(operatorAnd | operatorOr | operatorNot
+        | generalUnit | Suppress(White())) | Empty())
+
+    toplevel = Group(expression).setResultsName("Toplevel") + StringEnd()
+
+    return toplevel.parseString
+
+
+DEFAULT_PARSER = _make_default_parser()

--- a/tiddlywebplugins/sqlalchemy3/producer.py
+++ b/tiddlywebplugins/sqlalchemy3/producer.py
@@ -1,0 +1,248 @@
+"""
+Produce a sqlalchemy query object from the parser AST.
+"""
+
+from sqlalchemy.orm import aliased
+from sqlalchemy.sql.expression import (and_, or_, not_, text as text_, label)
+from sqlalchemy.sql import func
+
+from tiddlyweb.store import StoreError
+
+from tiddlywebplugins.sqlalchemy3 import (sField, sTag, sText, sTiddler,
+        sRevision)
+
+
+class Producer(object):
+    """
+    Turn a tiddlywebplugins.mysql.parser AST into a sqlalchemy query.
+    """
+
+    def produce(self, ast, query, fulltext=False):
+        """
+        Given an ast and an empty query, build that query into a
+        full select, based on the info in the ast.
+        """
+        self.joined_revision = False
+        self.joined_tags = False
+        self.joined_fields = False
+        self.joined_text = False
+        self.in_and = False
+        self.in_or = False
+        self.in_not = False
+        self.limit = None
+        self.query = query
+        self.fulltext = fulltext
+        expressions = self._eval(ast, None)
+        if self.limit:
+            self.query = self.query.filter(expressions).limit(self.limit)
+        else:
+            self.query = self.query.filter(expressions)
+        return self.query
+
+    def _eval(self, node, fieldname):
+        name = node.getName()
+        return getattr(self, "_" + name)(node, fieldname)
+
+    def _Toplevel(self, node, fieldname):
+        expressions = []
+        for subnode in node:
+            expression = self._eval(subnode, fieldname)
+            # Check to confirm that the expression is a proper
+            # expression, otherwise don't add it. None is used
+            # to indicate the producer sort of fell through
+            if expression is not None:
+                expressions.append(expression)
+        return and_(*expressions)
+
+    def _Word(self, node, fieldname):
+        value = node[0]
+        if fieldname:
+            like = False
+            try:
+                if value.endswith('*'):
+                    value = value.replace('*', '%')
+                    like = True
+            except TypeError:
+                # Hack around field values containing parens
+                # The node[0] is a non-string if that's the case.
+                node[0] = '(' + value[0] + ')'
+                return self._Word(node, fieldname)
+
+            if fieldname == 'ftitle':
+                fieldname = 'title'
+            if fieldname == 'fbag':
+                fieldname = 'bag'
+
+            if fieldname == 'bag':
+                if like:
+                    expression = (sTiddler.bag.like(value))
+                else:
+                    expression = (sTiddler.bag == value)
+            elif fieldname == 'title':
+                if like:
+                    expression = (sTiddler.title.like(value))
+                else:
+                    expression = (sTiddler.title == value)
+            elif fieldname == 'id':
+                bag, title = value.split(':', 1)
+                expression = and_(sTiddler.bag == bag,
+                        sTiddler.title == title)
+            elif fieldname == 'tag':
+                if self.in_and:
+                    tag_alias = aliased(sTag)
+                    self.query = self.query.join(tag_alias)
+                    if like:
+                        expression = (tag_alias.tag.like(value))
+                    else:
+                        expression = (tag_alias.tag == value)
+                else:
+                    if not self.joined_tags:
+                        self.query = self.query.join(sTag)
+                        if like:
+                            expression = (sTag.tag.like(value))
+                        else:
+                            expression = (sTag.tag == value)
+                        self.joined_tags = True
+                    else:
+                        if like:
+                            expression = (sTag.tag.like(value))
+                        else:
+                            expression = (sTag.tag == value)
+            elif fieldname == 'near':
+                # proximity search on geo.long, geo.lat based on
+                # http://cdent.tiddlyspace.com/bags/cdent_public/tiddlers/Proximity%20Search.html
+                try:
+                    lat, long, radius = [float(item)
+                            for item in value.split(',', 2)]
+                except ValueError, exc:
+                    raise StoreError(
+                            'failed to parse search query, malformed near: %s'
+                            % exc)
+                field_alias1 = aliased(sField)
+                field_alias2 = aliased(sField)
+                distance = label(u'greatcircle', (6371000
+                    * func.acos(
+                        func.cos(
+                            func.radians(lat))
+                        * func.cos(
+                            func.radians(field_alias2.value))
+                        * func.cos(
+                            func.radians(field_alias1.value)
+                            - func.radians(long))
+                        + func.sin(
+                            func.radians(lat))
+                        * func.sin(
+                            func.radians(field_alias2.value)))))
+                self.query = self.query.add_columns(distance)
+                self.query = self.query.join(field_alias1)
+                self.query = self.query.join(field_alias2)
+                self.query = self.query.having(
+                        u'greatcircle < %s' % radius).order_by('greatcircle')
+                expression = and_(field_alias1.name == u'geo.long',
+                        field_alias2.name == u'geo.lat')
+                self.limit = 20  # XXX: make this passable
+            elif fieldname == '_limit':
+                try:
+                    self.limit = int(value)
+                except ValueError:
+                    pass
+                self.query = self.query.order_by(
+                        sRevision.modified.desc())
+                expression = None
+            elif fieldname == 'text':
+                if not self.joined_text:
+                    self.query = self.query.join(sText)
+                    self.joined_text = True
+                if self.fulltext:
+                    expression = (text_(
+                        'MATCH(text.text) '
+                        + "AGAINST('%s' in boolean mode)" % value))
+                else:
+                    value = '%' + value + '%'
+                    expression = sText.text.like(value)
+            elif fieldname in ['modifier', 'modified', 'type']:
+                if like:
+                    expression = (getattr(sRevision,
+                        fieldname).like(value))
+                else:
+                    expression = (getattr(sRevision,
+                        fieldname) == value)
+            else:
+                if self.in_and:
+                    field_alias = aliased(sField)
+                    self.query = self.query.join(field_alias)
+                    expression = (field_alias.name == fieldname)
+                    if like:
+                        expression = and_(expression,
+                                field_alias.value.like(value))
+                    else:
+                        expression = and_(expression,
+                                field_alias.value == value)
+                else:
+                    if not self.joined_fields:
+                        self.query = self.query.join(sField)
+                        expression = (sField.name == fieldname)
+                        if like:
+                            expression = and_(expression,
+                                    sField.value.like(value))
+                        else:
+                            expression = and_(expression,
+                                    sField.value == value)
+                        self.joined_fields = True
+                    else:
+                        expression = (sField.name == fieldname)
+                        if like:
+                            expression = and_(expression,
+                                    sField.value.like(value))
+                        else:
+                            expression = and_(expression,
+                                    sField.value == value)
+        else:
+            if not self.joined_text:
+                self.query = self.query.join(sText)
+                self.joined_text = True
+            if self.fulltext:
+                expression = (text_(
+                    'MATCH(text.text) '
+                    + "AGAINST('%s' in boolean mode)" % value))
+            else:
+                value = '%' + value + '%'
+                expression = sText.text.like(value)
+        return expression
+
+    def _Field(self, node, fieldname):
+        return self._Word(node[1], node[0])
+
+    def _Group(self, node, fieldname):
+        expressions = []
+        for subnode in node:
+            expressions.append(self._eval(subnode, fieldname))
+        return and_(*expressions)
+
+    def _Or(self, node, fieldname):
+        expressions = []
+        self.in_or = True
+        for subnode in node:
+            expressions.append(self._eval(subnode, fieldname))
+        self.in_or = False
+        return or_(*expressions)
+
+    def _And(self, node, fieldname):
+        expressions = []
+        self.in_and = True
+        for subnode in node:
+            expressions.append(self._eval(subnode, fieldname))
+        self.in_and = False
+        return and_(*expressions)
+
+    def _Not(self, node, fieldname):
+        expressions = []
+        self.in_not = True
+        for subnode in node:
+            expressions.append(self._eval(subnode, fieldname))
+        self.in_not = False
+        return not_(*expressions)
+
+    def _Quotes(self, node, fieldname):
+        node[0] = '"%s"' % node[0]
+        return self._Word(node, fieldname)

--- a/tiddlywebplugins/sqlalchemy3/producer.py
+++ b/tiddlywebplugins/sqlalchemy3/producer.py
@@ -17,7 +17,7 @@ class Producer(object):
     Turn a tiddlywebplugins.sqalchemy3.parser AST into a sqlalchemy query.
     """
 
-    def produce(self, ast, query, fulltext=False):
+    def produce(self, ast, query, fulltext=False, geo=False):
         """
         Given an ast and an empty query, build that query into a
         full select, based on the info in the ast.
@@ -32,6 +32,7 @@ class Producer(object):
         self.limit = None
         self.query = query
         self.fulltext = fulltext
+        self.geo = geo
         expressions = self._eval(ast, None)
         if self.limit:
             self.query = self.query.filter(expressions).limit(self.limit)
@@ -108,7 +109,7 @@ class Producer(object):
                             expression = (sTag.tag.like(value))
                         else:
                             expression = (sTag.tag == value)
-            elif fieldname == 'near':
+            elif fieldname == 'near' and self.geo:
                 # proximity search on geo.long, geo.lat based on
                 # http://cdent.tiddlyspace.com/bags/cdent_public/tiddlers/Proximity%20Search.html
                 try:

--- a/tiddlywebplugins/sqlalchemy3/producer.py
+++ b/tiddlywebplugins/sqlalchemy3/producer.py
@@ -14,7 +14,7 @@ from tiddlywebplugins.sqlalchemy3 import (sField, sTag, sText, sTiddler,
 
 class Producer(object):
     """
-    Turn a tiddlywebplugins.mysql.parser AST into a sqlalchemy query.
+    Turn a tiddlywebplugins.sqalchemy3.parser AST into a sqlalchemy query.
     """
 
     def produce(self, ast, query, fulltext=False):


### PR DESCRIPTION
This is being done because the search query parser produces generic sql that in most cases will work for anything that suports sql, so may as well make it available. Those features which are not generic (such as fulltext searching and `near:<lat>,<lon>`) are guarded by config or class attributes.

A quick review by @pads or @FND would be awesome.
